### PR TITLE
Styled Buttons 변수명 변경 및 import 방식 변경에 따른 적용

### DIFF
--- a/components/Buttons/index.tsx
+++ b/components/Buttons/index.tsx
@@ -1,5 +1,5 @@
 import { MouseEventHandler, ReactNode } from 'react';
-import { S_L, S_M, S_MS, S_S, S_TAB, S_MENU, S_BADGE } from './styled';
+import * as Styled from './styled';
 
 interface IButtonProps {
   children: ReactNode;
@@ -34,41 +34,41 @@ interface IMenuButtonProps extends IButtonProps {
 
 export function L({ onClick, disabled, children }: ILButtonProps) {
   return (
-    <S_L onClick={onClick} disabled={disabled}>
+    <Styled.L onClick={onClick} disabled={disabled}>
       {children}
-    </S_L>
+    </Styled.L>
   );
 }
 
 export function M({ onClick, disabled, color, children }: IMButtonProps) {
   return (
-    <S_M onClick={onClick} disabled={disabled} color={color}>
+    <Styled.M onClick={onClick} disabled={disabled} color={color}>
       {children}
-    </S_M>
+    </Styled.M>
   );
 }
 
 export function MS({ onClick, color, children }: IMSButtonProps) {
   return (
-    <S_MS onClick={onClick} color={color}>
+    <Styled.MS onClick={onClick} color={color}>
       {children}
-    </S_MS>
+    </Styled.MS>
   );
 }
 
 export function S({ onClick, color, children }: ISButtonProps) {
   return (
-    <S_S onClick={onClick} color={color}>
+    <Styled.S onClick={onClick} color={color}>
       {children}
-    </S_S>
+    </Styled.S>
   );
 }
 
 export function Tab({ onClick, isActive, children }: ITabButtonProps) {
   return (
-    <S_TAB onClick={onClick} isActive={isActive}>
+    <Styled.TAB onClick={onClick} isActive={isActive}>
       {children}
-    </S_TAB>
+    </Styled.TAB>
   );
 }
 
@@ -79,10 +79,10 @@ export function Menu({
   children
 }: IMenuButtonProps) {
   return (
-    <S_MENU onClick={onClick} isActive={isActive}>
+    <Styled.MENU onClick={onClick} isActive={isActive}>
       {children}
-      {!!badgeCount && <S_BADGE>{badgeCount}</S_BADGE>}
-    </S_MENU>
+      {!!badgeCount && <Styled.BADGE>{badgeCount}</Styled.BADGE>}
+    </Styled.MENU>
   );
 }
 

--- a/components/Buttons/styled.ts
+++ b/components/Buttons/styled.ts
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 import { COLOR } from '../../shared/constants';
 
-export const S_L = styled.button`
+export const L = styled.button`
   width: 22rem;
   height: 6.8rem;
   color: ${COLOR.white};
@@ -12,7 +12,7 @@ export const S_L = styled.button`
   border-radius: 0.5rem;
 `;
 
-export const S_M = styled.button`
+export const M = styled.button`
   width: 48rem;
   height: 6rem;
   color: ${(props) => (props.color === 'white' ? COLOR.grey76 : COLOR.white)};
@@ -37,7 +37,7 @@ export const S_M = styled.button`
   border-radius: 0.5rem;
 `;
 
-export const S_MS = styled.button`
+export const MS = styled.button`
   width: 16.8rem;
   height: 5.4rem;
   font-size: 1.6rem;
@@ -68,7 +68,7 @@ export const S_MS = styled.button`
   align-items: center;
 `;
 
-export const S_S = styled.button`
+export const S = styled.button`
   width: 8rem;
   height: 4rem;
   ${(props) => {
@@ -93,7 +93,7 @@ export const S_S = styled.button`
   border-radius: 0.5rem;
 `;
 
-export const S_TAB = styled.button<{ isActive: boolean }>`
+export const TAB = styled.button<{ isActive: boolean }>`
   width: 32rem;
   height: 6rem;
   color: ${(props) => (props.isActive ? COLOR.accentColor : COLOR.grey76)};
@@ -105,7 +105,7 @@ export const S_TAB = styled.button<{ isActive: boolean }>`
     props.isActive ? COLOR.accentColor : COLOR.greyE0};
 `;
 
-export const S_MENU = styled.button<{ isActive: boolean }>`
+export const MENU = styled.button<{ isActive: boolean }>`
   width: 25rem;
   height: 5rem;
   font-size: 1.6rem;
@@ -124,7 +124,7 @@ export const S_MENU = styled.button<{ isActive: boolean }>`
   }
 `;
 
-export const S_BADGE = styled.span`
+export const BADGE = styled.span`
   height: 2rem;
   color: ${COLOR.white};
   font-size: 1.2rem;


### PR DESCRIPTION
# 🔀 PR

## 종류
- [ ] 기능 추가
- [ ] 기능 및 버그 수정
- [x] 리팩토링
- [ ] 세팅
- [ ] CI/CD

## 설명
- Styled Buttons 변수명에서 대문자 S를 제거
- Styled components의 import 방식을 `* as Styled`로 바꾼 데에 따른 Buttons 컴포넌트의 이름 변경

## 이슈 번호
- #16 
